### PR TITLE
upgrade nalgebra

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,6 @@ include = ["Cargo.toml", "LICENSE", "README.md", "src/main.rs"]
 
 [dependencies]
 getopts = "0.2"
-kiss3d = "0.12"
-nalgebra = "0.13"
+kiss3d = "0.16.4"
+nalgebra = "0.16.6"
 rand = "0.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -305,9 +305,9 @@ impl Net {
                         continue;
                     }
                     self.window.draw_line(
-                        &Point3::from_coordinates(n.position()),
-                        &Point3::from_coordinates(self.node(b).position()),
-                        &Point3::from_coordinates(color),
+                        &Point3::from(n.position()),
+                        &Point3::from(self.node(b).position()),
+                        &Point3::from(color),
                     );
                 }
             }


### PR DESCRIPTION
due to rust-lang/rust#49799, older nalgebra versions will break.

Though this is trivial, I have submitted a CLA as mentioned in CONTRIBUTING.